### PR TITLE
add clippy to CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,3 +45,8 @@ jobs:
           args: --all -- --check
         # "ignore" param in rustfmt.toml is only supported on nightly
         if: ${{ matrix.rust == 'nightly' }}
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy


### PR DESCRIPTION
this closes #15 

Here is an example of what that looks like, if it catches a warning https://github.com/good-praxis/hcloud-rust/pull/3/commits/9290a7b8869783b5f1a1ccd8329bf81ed61a6b47

Full on errors are caught by the preceding tests, though