### PR TITLE
add clippy to workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,3 +45,9 @@ jobs:
           args: --all -- --check
         # "ignore" param in rustfmt.toml is only supported on nightly
         if: ${{ matrix.rust == 'nightly' }}
+
+      - name: Run Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features


### PR DESCRIPTION
This fixes #15 and actually works this time around.

It's using https://github.com/marketplace/actions/rust-clippy-check 
It will fail on new warnings added in a PR

Check out https://github.com/actions-rs/example/pull/2/files for an example and  is limited by https://github.com/actions-rs/clippy-check/issues/2