### PR TITLE
Replace bash scripts with `xshell` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 rustls-tls = ["reqwest/rustls-tls"]
-xshell = ["dep:xshell", "dep:anyhow"]
+generator_scripts = ["dep:xshell", "dep:anyhow", "dep:tokio"]
 
 [dependencies]
 serde = "^1.0"
@@ -25,6 +25,7 @@ serde_json = "^1.0"
 url = "^2.2"
 xshell = {version="^0.2", optional=true}
 anyhow = {version="^1.0", optional=true}
+tokio = {version = "^1.0", features=["macros", "rt-multi-thread"], optional=true}
 
 [dependencies.reqwest]
 version = "^0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 rustls-tls = ["reqwest/rustls-tls"]
+xshell = ["dep:xshell", "dep:anyhow"]
 
 [dependencies]
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
+xshell = {version="^0.2", optional=true}
+anyhow = {version="^1.0", optional=true}
 
 [dependencies.reqwest]
 version = "^0.11"

--- a/src/bin/download_openapi_spec.rs
+++ b/src/bin/download_openapi_spec.rs
@@ -1,0 +1,36 @@
+// Download OpenAPI spec for the Hetzner Cloud API
+
+#[cfg(feature = "xshell")]
+mod script {
+    use anyhow::Result;
+    use hcloud::config::Config;
+    use xshell::{cmd, Shell};
+    pub fn run() -> Result<()> {
+        let Config {
+            download_dir,
+            hcloud_openapi_version,
+            hcloud_openapi_url,
+            hcloud_openapi_json,
+            ..
+        } = Config::default();
+        println!(
+            "Downloading version {} of the OpenAPI spec for the Hetzner Cloud API...",
+            hcloud_openapi_version
+        );
+
+        let sh = Shell::new()?;
+        cmd!(sh, "mkdir -p {download_dir}").run()?;
+
+        cmd!(sh, "curl -L {hcloud_openapi_url} -o {hcloud_openapi_json}").run()?;
+
+        Ok(())
+    }
+}
+
+fn main() {
+    #[cfg(feature = "xshell")]
+    script::run().unwrap();
+
+    #[cfg(not(feature = "xshell"))]
+    panic!("This binary is only available when compiled with the `xshell` feature.");
+}

--- a/src/bin/download_openapi_spec.rs
+++ b/src/bin/download_openapi_spec.rs
@@ -1,6 +1,6 @@
 // Download OpenAPI spec for the Hetzner Cloud API
 
-#[cfg(feature = "xshell")]
+#[cfg(feature = "generator_scripts")]
 mod script {
     use anyhow::Result;
     use hcloud::config::Config;
@@ -27,10 +27,13 @@ mod script {
     }
 }
 
-fn main() {
-    #[cfg(feature = "xshell")]
+#[cfg_attr(feature = "generator_scripts", tokio::main)]
+#[cfg(feature = "generator_scripts")]
+async fn main() {
     script::run().unwrap();
+}
 
-    #[cfg(not(feature = "xshell"))]
-    panic!("This binary is only available when compiled with the `xshell` feature.");
+#[cfg(not(feature = "generator_scripts"))]
+fn main() {
+    panic!("This binary is only available when compiled with the `generator_scripts` feature.");
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "xshell")]
+#[cfg(feature = "generator_scripts")]
 pub struct Config {
     pub download_dir: &'static str,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "xshell")]
+pub struct Config {
+    pub download_dir: &'static str,
+
+    pub generator_version: &'static str,
+    pub generator_url: String,
+    pub generator_jar: String,
+
+    pub hcloud_openapi_version: &'static str,
+    pub hcloud_openapi_url: String,
+    pub hcloud_openapi_json: String,
+}
+impl Config {
+    pub fn default() -> Self {
+        const DOWNLOAD_DIR: &str = "generator_files";
+        const GENERATOR_VERSION: &str = "5.4.0";
+        const HCLOUD_OPENAPI_VERSION: &str = "0.7.0";
+
+        Config {
+            download_dir: DOWNLOAD_DIR,
+            generator_version: GENERATOR_VERSION,
+            generator_url: format!("https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/{}/openapi-generator-cli-{}.jar", GENERATOR_VERSION,GENERATOR_VERSION),
+            generator_jar: format!("{}/openapi-generator-cli-{}.jar", DOWNLOAD_DIR, GENERATOR_VERSION),
+            hcloud_openapi_version: HCLOUD_OPENAPI_VERSION,
+            hcloud_openapi_url: format!(
+            "https://github.com/MaximilianKoestler/hcloud-openapi/releases/download/v{}/hcloud.json",HCLOUD_OPENAPI_VERSION
+            ),
+            hcloud_openapi_json: format!("{}/hcloud_{}.json", DOWNLOAD_DIR, HCLOUD_OPENAPI_VERSION),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,5 +68,5 @@ extern crate url;
 pub mod apis;
 pub mod models;
 
-#[cfg(feature = "xshell")]
+#[cfg(feature = "generator_scripts")]
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,3 +67,6 @@ extern crate url;
 
 pub mod apis;
 pub mod models;
+
+#[cfg(feature = "xshell")]
+pub mod config;


### PR DESCRIPTION
Here is a little upcoming attempt to offer a replacement to the used bash scripts of this project -- for no practical reason except to increase the rust percentage of this repository.

I am using [xshell](https://docs.rs/xshell/latest/xshell/) to accomplish this, and as of tonight the first of the three scripts is implemented and functional

If you check this PR out and want to give it a whirl, be sure to add `--all-features` to your cargo call, you can call the first script by running `cargo run --bin download_openapi_spec --all-features`