### PR TITLE
Remove hard dependency on `reqwest/default-tls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_with = { version = "^3.8", default-features = false, features = [
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", default_features = false, features = [
+reqwest = { version = "^0.12", default-features = false, features = [
     "charset",
     "http2",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,13 @@ serde_with = { version = "^3.8", default-features = false, features = [
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default_features = false, features = [
+    "charset",
+    "http2",
+    "json",
+    "macos-system-configuration",
+    "multipart",
+] }
 
 [dev-dependencies]
 rand = "^0.8"


### PR DESCRIPTION
The `reqwest` dependency was specified with all its default features, which [includes `default-tls`](https://github.com/seanmonstar/reqwest/blob/95fec09be9503d82c574f94e37dde0a814d1f850/Cargo.toml#L30). Even by using `hcloud-cloud` with its `rustls-tls` feature wouldn't remove the `default-tls` dependency.

```
[dependencies]
hcloud = { version = "0.20", default-features = false, features = ["rustls-tls"] }
```

```
$ cargo tree -e features -i reqwest
reqwest v0.12.8
├── reqwest feature "__rustls"
│   └── reqwest feature "rustls-tls-webpki-roots"
│       └── reqwest feature "rustls-tls"
│           └── hcloud feature "rustls-tls"
│               └── ...
...
├── reqwest feature "__tls"
│   ├── reqwest feature "__rustls" (*)
│   └── reqwest feature "default-tls"                        <- default-tls included here
│       └── reqwest feature "default"
│           └── hcloud v0.20.0
│               └── hcloud feature "rustls-tls" (*)          <- hcloud with rustls-tls here
...
```

This PR removes the default features of reqwest to avoid the `default-tls` feature. When doing this, we lose some of the other default features, so this PR also lists those features specifically to avoid losing them.