### PR TITLE
Do not run examples on PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,6 +45,7 @@ jobs:
         run: cargo clippy --all-targets
 
       - name: Run examples
+        if: ${{ github.event_name != 'pull_request'}}
         env:
           HCLOUD_API_TOKEN: ${{ secrets.HCLOUD_API_TOKEN }}
         run: |


### PR DESCRIPTION
This disables running the examples step for PR CI runs. As the API token is not available for PRs, the build otherwise fails.

