### PR TITLE
Manually remove "datacenter" property after removal by Hetzner

### DIFF
--- a/src/apis/primary_ips_api.rs
+++ b/src/apis/primary_ips_api.rs
@@ -41,7 +41,7 @@ pub struct ChangeReverseDnsRecordsForPrimaryIpParams {
 /// struct for passing parameters to the method [`create_primary_ip`]
 #[derive(Clone, Debug, Default)]
 pub struct CreatePrimaryIpParams {
-    /// Request Body for creating a new Primary IP.  The `location`, `datacenter` and `assignee_id`/`assignee_type` attributes are mutually exclusive.
+    /// Request Body for creating a new Primary IP.  The `location` and `assignee_id`/`assignee_type` attributes are mutually exclusive.
     pub create_primary_ip_request: models::CreatePrimaryIpRequest,
 }
 
@@ -397,7 +397,7 @@ pub async fn change_reverse_dns_records_for_primary_ip(
     }
 }
 
-/// Create a new Primary IP.  Can optionally be assigned to a resource by providing an `assignee_id` and `assignee_type`.  If not assigned to a resource the `location` key needs to be provided. This can be either the ID or the name of the Location this Primary IP shall be created in.  A Primary IP can only be assigned to resource in the same Location later on.  The `datacenter` key is deprecated in favor of `location` and will be removed after 01 July 2026.  #### Call specific error codes  | Code                          | Description                                                              | |------------------------------ |------------------------------------------------------------------------- | | `server_not_stopped`          | The specified Server is running, but needs to be powered off | | `server_has_ipv4`             | The Server already has an ipv4 address                       | | `server_has_ipv6`             | The Server already has an ipv6 address                       |
+/// Create a new Primary IP.  Can optionally be assigned to a resource by providing an `assignee_id` and `assignee_type`.  If not assigned to a resource the `location` key needs to be provided. This can be either the ID or the name of the Location this Primary IP shall be created in.  A Primary IP can only be assigned to resource in the same Location later on.  #### Call specific error codes  | Code                          | Description                                                              | |------------------------------ |------------------------------------------------------------------------- | | `server_not_stopped`          | The specified Server is running, but needs to be powered off | | `server_has_ipv4`             | The Server already has an ipv4 address                       | | `server_has_ipv6`             | The Server already has an ipv6 address                       |
 pub async fn create_primary_ip(
     configuration: &configuration::Configuration,
     params: CreatePrimaryIpParams,

--- a/src/models/create_primary_ip_request.rs
+++ b/src/models/create_primary_ip_request.rs
@@ -28,13 +28,10 @@ pub struct CreatePrimaryIpRequest {
     /// Auto deletion state.  If enabled the Primary IP will be deleted once the assigned resource gets deleted.
     #[serde(rename = "auto_delete", skip_serializing_if = "Option::is_none")]
     pub auto_delete: Option<bool>,
-    /// **Deprecated**: This property is deprecated and will be removed after 1 July 2026. Use the `location` key instead.  Data Center ID or name.  The Primary IP will be bound to this Data Center. Omit if `assignee_id`/`assignee_type` or `location` are provided.
-    #[serde(rename = "datacenter", skip_serializing_if = "Option::is_none")]
-    pub datacenter: Option<String>,
     /// User-defined labels (`key/value` pairs) for the Resource. For more information, see \"Labels\".  | User-defined labels (`key/value` pairs) for the Resource.  Note that the set of Labels provided in the request will overwrite the existing one.  For more information, see \"Labels\".
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<std::collections::HashMap<String, String>>,
-    /// Location ID or name the Primary IP will be bound to.  Omit if `assignee_id`/`assignee_type` or `datacenter` are provided.
+    /// Location ID or name the Primary IP will be bound to.  Omit if `assignee_id`/`assignee_type` is provided.
     #[serde(rename = "location", skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
     /// Name of the Resource. Must be unique per Project.
@@ -55,7 +52,6 @@ impl CreatePrimaryIpRequest {
             assignee_id: None,
             assignee_type,
             auto_delete: None,
-            datacenter: None,
             labels: None,
             location: None,
             name,

--- a/src/models/create_server_request.rs
+++ b/src/models/create_server_request.rs
@@ -17,9 +17,6 @@ pub struct CreateServerRequest {
     /// Auto-mount Volumes after attach.
     #[serde(rename = "automount", skip_serializing_if = "Option::is_none")]
     pub automount: Option<bool>,
-    /// **Deprecated**: This property is deprecated and will be removed after the 1 July 2026. Use the `location` property instead.  ID or name of the Data Center to create Server in (must not be used together with `location`).
-    #[serde(rename = "datacenter", skip_serializing_if = "Option::is_none")]
-    pub datacenter: Option<String>,
     /// Firewalls which should be applied on the Server's public network interface at creation time.
     #[serde(rename = "firewalls", skip_serializing_if = "Option::is_none")]
     pub firewalls: Option<Vec<models::CreateServerRequestFirewalls>>,
@@ -29,7 +26,7 @@ pub struct CreateServerRequest {
     /// User-defined labels (`key/value` pairs) for the Resource. For more information, see \"Labels\".  | User-defined labels (`key/value` pairs) for the Resource.  Note that the set of Labels provided in the request will overwrite the existing one.  For more information, see \"Labels\".
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<std::collections::HashMap<String, String>>,
-    /// ID or name of the Location to create the Server in (must not be used together with `datacenter`).
+    /// ID or name of the Location to create the Server in.
     #[serde(rename = "location", skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
     /// Name of the Server to create (must be unique per Project and a valid hostname as per RFC 1123).
@@ -65,7 +62,6 @@ impl CreateServerRequest {
     pub fn new(image: String, name: String, server_type: String) -> CreateServerRequest {
         CreateServerRequest {
             automount: None,
-            datacenter: None,
             firewalls: None,
             image,
             labels: None,

--- a/src/models/data_center.rs
+++ b/src/models/data_center.rs
@@ -11,7 +11,7 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
-/// DataCenter : **Deprecated**: This property is deprecated and will be removed after the 1 July 2026. Use the `location` property instead.  Data Center of the Primary IP.  | **Deprecated**: This property is deprecated and will be removed after the 1 July 2026. Use the `location` property instead.  Data Center this Resource is located at.
+/// DataCenter : Data Center of the Primary IP.  Data Center this Resource is located at.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DataCenter {
     /// Descriptive name for the Data Center.  Desired to be easy to understand for humans. Might be changed for cosmetic reasons. Do not use this as an identifier.

--- a/src/models/primary_ip.rs
+++ b/src/models/primary_ip.rs
@@ -28,9 +28,6 @@ pub struct PrimaryIp {
     /// Point in time when the Resource was created (in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) format).
     #[serde(rename = "created")]
     pub created: String,
-    /// **Deprecated**: This property is deprecated and will be removed after the 1 July 2026. Use the `location` property instead.  Data Center of the Primary IP.
-    #[serde(rename = "datacenter")]
-    pub datacenter: Box<models::DataCenter>,
     /// List of reverse DNS records.
     #[serde(rename = "dns_ptr")]
     pub dns_ptr: Vec<models::DnsPtr>,
@@ -61,7 +58,6 @@ impl PrimaryIp {
         auto_delete: bool,
         blocked: bool,
         created: String,
-        datacenter: models::DataCenter,
         dns_ptr: Vec<models::DnsPtr>,
         id: i64,
         ip: String,
@@ -77,7 +73,6 @@ impl PrimaryIp {
             auto_delete,
             blocked,
             created,
-            datacenter: Box::new(datacenter),
             dns_ptr,
             id,
             ip,

--- a/src/models/server.rs
+++ b/src/models/server.rs
@@ -20,9 +20,6 @@ pub struct Server {
     /// Point in time when the Resource was created (in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) format).
     #[serde(rename = "created")]
     pub created: String,
-    /// **Deprecated**: This property is deprecated and will be removed after the 1 July 2026. Use the `location` property instead.  Data Center this Resource is located at.
-    #[serde(rename = "datacenter")]
-    pub datacenter: Box<models::DataCenter>,
     /// ID of the Server.
     #[serde(rename = "id")]
     pub id: i64,
@@ -90,7 +87,6 @@ impl Server {
     pub fn new(
         backup_window: Option<String>,
         created: String,
-        datacenter: models::DataCenter,
         id: i64,
         image: Option<models::Image>,
         included_traffic: Option<i64>,
@@ -112,7 +108,6 @@ impl Server {
         Server {
             backup_window,
             created,
-            datacenter: Box::new(datacenter),
             id,
             image: image.map(Box::new),
             included_traffic,


### PR DESCRIPTION
This property on servers and primary IPs was removed by Hetzner as previously announced. Because the version of the OpenAPI spec we are using is not updated, yet, the code has been modified manually.

Fixes #41